### PR TITLE
Add 31-sector Olymp type

### DIFF
--- a/frontend/src/components/SettingsForm.vue
+++ b/frontend/src/components/SettingsForm.vue
@@ -51,6 +51,7 @@
           <label class="form-label">Тип уровня</label>
           <select v-model="store.uploadType" class="form-select h-10 w-full">
             <option value="olymp">Олимпийка (15 секторов)</option>
+            <option value="olymp31">Олимпийка (31 сектор)</option>
           </select>
         </div>
       </div>
@@ -70,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useUploadStore } from '../store'
@@ -79,6 +80,14 @@ import { useAuthStore } from '../store/auth'
 const store = useUploadStore()
 const authStore = useAuthStore()
 const router = useRouter()
+
+watch(
+  () => store.uploadType,
+  (val) => {
+    store.setUploadType(val)
+  },
+  { immediate: true }
+)
 
 // Общая ошибка проверки (домен/игра/авторизация)
 const error = ref('')

--- a/frontend/src/components/UploadForm.vue
+++ b/frontend/src/components/UploadForm.vue
@@ -8,6 +8,7 @@
 import { computed } from 'vue'
 import { useUploadStore } from '../store'
 import Olymp15 from './types/Olymp15/index.vue'
+import Olymp31 from './types/Olymp31/index.vue'
 
 const store = useUploadStore()
 
@@ -15,6 +16,8 @@ const currentComponent = computed(() => {
   switch (store.uploadType) {
     case 'olymp':
       return Olymp15
+    case 'olymp31':
+      return Olymp31
     // здесь позже добавим case для других типов
     default:
       return Olymp15

--- a/frontend/src/components/types/Olymp31/index.vue
+++ b/frontend/src/components/types/Olymp31/index.vue
@@ -1,0 +1,482 @@
+<template>
+  <div class="min-h-screen bg-blue-50 py-8">
+    <div class="container mx-auto bg-white p-12 rounded-md shadow-sm">
+      <!-- Заголовок -->
+      <h1 class="text-2xl font-semibold text-center">
+        {{ levelTypeLabel }}
+      </h1>
+
+      <!-- Информация об авторе и настройках -->
+      <p class="text-sm text-gray-500 text-center mb-0">
+        автор: <strong>{{ authStore.username }}</strong>,
+        домен: <strong>{{ store.domain }}</strong>,
+        игра: <strong>{{ store.gameId }}</strong>,
+        уровень: <strong>{{ store.levelId }}</strong>
+      </p>
+
+      <!-- Ошибка валидации/отправки -->
+      <div v-if="error" class="text-red-500 text-sm mt-4">{{ error }}</div>
+
+      <!-- Глобальные контролы -->
+      <div class="flex flex-wrap justify-between items-end gap-4 mt-8 mb-8">
+        <!-- Режим закрытия уровня -->
+        <div class="flex-1 min-w-[160px]">
+          <label class="form-label">Закрытие уровня</label>
+          <select
+            v-model="sectorMode"
+            @change="applySectorMode"
+            class="form-select h-10 w-full cursor-pointer"
+          >
+            <option value="all">Все сектора</option>
+            <option value="initialAndFinal">Начальные + финал</option>
+            <option value="finalOnly">Только финал</option>
+            <option value="custom">Кастом</option>
+          </select>
+        </div>
+
+        <!-- Быстрое бонусное время -->
+        <div class="flex-1 min-w-[240px]">
+          <label class="form-label">Бонусное время (ч, м, с)</label>
+          <div class="flex items-center gap-2">
+            <input
+              type="number"
+              min="0"
+              v-model.number="quickTime.hours"
+              placeholder="ч"
+              class="form-input h-10 w-16 text-center"
+            />
+            <input
+              type="number"
+              min="0"
+              v-model.number="quickTime.minutes"
+              placeholder="м"
+              class="form-input h-10 w-16 text-center"
+            />
+            <input
+              type="number"
+              min="0"
+              v-model.number="quickTime.seconds"
+              placeholder="с"
+              class="form-input h-10 w-16 text-center"
+            />
+            <label class="flex items-center gap-1 ml-2">
+              <input
+                type="checkbox"
+                v-model="quickTime.negative"
+                class="cursor-pointer"
+              />
+              <span class="text-gray-500">–</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Шаблон закрытого сектора -->
+        <div class="flex-1 min-w-[240px]">
+          <label class="form-label">Название закрытого сектора</label>
+          <input
+            v-model="localClosedPattern"
+            placeholder="Текст, & или URL картинки"
+            class="form-input h-10 w-full"
+          />
+        </div>
+
+        <!-- Быстрая кнопка заполнения открытых -->
+        <button
+          @click="fillOpenSectors"
+          type="button"
+          class="form-button h-10 px-4 flex-1 min-w-[240px]"
+        >
+          Заполнить открытые сектора
+        </button>
+      </div>
+
+      <!-- Таблица ответов -->
+      <Answers />
+
+      <!-- Навигация и экспорт/импорт -->
+      <div class="flex flex-wrap justify-between gap-2 mt-8">
+        <div class="flex flex-wrap gap-2">
+          <button
+            @click="$router.push('/settings')"
+            class="form-button bg-gray-400 hover:bg-gray-500 h-10 px-4"
+          >
+            Назад
+          </button>
+        </div>
+        <div class="flex flex-wrap gap-2 px-4">
+          <button
+            @click="exportData"
+            type="button"
+            class="form-button h-10 px-4"
+          >
+            Экспорт
+          </button>
+          <label class="form-button h-10 px-4 cursor-pointer">
+            Импорт
+            <input
+              type="file"
+              @change="importData"
+              accept=".json"
+              class="hidden"
+            />
+          </label>
+          <button @click="showPreview = true" class="form-button h-10 px-4">
+            Предпросмотр
+          </button>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            @click="onSendTask"
+            type="button"
+            class="form-button h-10 px-4"
+          >
+            Залить задание
+          </button>
+          <button
+            @click="onSendSector"
+            type="button"
+            class="form-button h-10 px-4"
+          >
+            Залить секторы
+          </button>
+          <button
+            @click="onSendBonus"
+            type="button"
+            class="form-button h-10 px-4"
+          >
+            Залить бонусы
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Модальное окно Предпросмотра -->
+    <transition name="fade">
+      <div
+        v-if="showPreview"
+        class="fixed inset-0 bg-gray-600 bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50"
+      >
+        <div
+          class="bg-[#1d1d1d] text-white rounded-md p-6 w-[90%] max-w-3xl space-y-4 relative"
+        >
+          <button
+            @click="showPreview = false"
+            class="absolute top-2 right-2 text-gray-400 hover:text-white cursor-pointer"
+          >
+            ✕
+          </button>
+          <h2 class="text-xl font-semibold">Предпросмотр</h2>
+          <div class="flex gap-2 mb-4">
+            <button
+              :class="previewMode === 'closed' ? 'bg-blue-500 text-white' : 'bg-gray-400 text-black'"
+              class="px-4 py-2 rounded-md cursor-pointer"
+              @click="previewMode = 'closed'"
+            >
+              Закрытая
+            </button>
+            <button
+              :class="previewMode === 'open' ? 'bg-blue-500 text-white' : 'bg-gray-400 text-black'"
+              class="px-4 py-2 rounded-md cursor-pointer"
+              @click="previewMode = 'open'"
+            >
+              Открытая
+            </button>
+          </div>
+          <div class="overflow-auto max-h-[60vh]">
+            <div v-html="olympTableHtml"></div>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, watch, onMounted } from 'vue'
+import { useUploadStore } from '../../../store'
+import { useAuthStore } from '../../../store/auth'
+import Answers from '../Olymp15/Answers.vue'
+
+// Функции отправки из единого uploader.ts
+import {
+  sendTask,
+  sendSector,
+  sendBonuses,
+} from '../../../services/uploader'
+
+// --- Вспомогательная проверка «это ли ссылка на изображение?» ---
+function formatClosedText(text: string): string {
+  const trimmed = text.trim()
+  // Если начинается с http:// или https://
+  if (/^https?:\/\//i.test(trimmed)) {
+    // Оборачиваем в <a><img>…
+    return `<a href="${trimmed}" target="_blank"><img src="${trimmed}" style="max-width: 150px; max-height: 150px;"></a>`
+  }
+  return text
+}
+
+// Типы
+type SectorMode = 'all' | 'initialAndFinal' | 'finalOnly' | 'custom'
+type Cell = { id?: string; rs?: number }
+
+const store = useUploadStore()
+const authStore = useAuthStore()
+
+const error = ref('')
+const showPreview = ref(false)
+const previewMode = ref<'closed' | 'open'>('closed')
+
+// Заголовок
+const levelTypeLabel = computed(() =>
+  store.uploadType === 'olymp31'
+    ? 'Олимпийка (31 сектор)'
+    : store.uploadType
+)
+
+// Режим закрытия секторов
+const sectorMode = computed<SectorMode>({
+  get: () => store.config.sectorMode as SectorMode,
+  set: (v) => {
+    ;(store.config as any).sectorMode = v
+  },
+})
+
+// Быстрое заполнение бонусного времени
+const quickTime = reactive({
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+  negative: false,
+})
+watch(
+  () => ({ ...quickTime }),
+  (qt) => store.answers.forEach((r) => (r.bonusTime = { ...qt })), 
+  { deep: true }
+)
+
+// Шаблон закрытого сектора
+const localClosedPattern = ref('')
+watch(localClosedPattern, (val) =>
+  store.answers.forEach((r) => {
+    r.closedText = val.replace(/&/g, String(r.number))
+  })
+)
+onMounted(() => {
+  localClosedPattern.value = ''
+})
+
+// Применение режима закрытия секторов
+function applySectorMode() {
+  switch (sectorMode.value) {
+    case 'all':
+      store.answers.forEach((r) => (r.inSector = true))
+      break
+    case 'initialAndFinal':
+      store.answers.forEach((r) => {
+        r.inSector = r.number <= 16 || r.number === 31
+      })
+      break
+    case 'finalOnly':
+      store.answers.forEach((r) => {
+        r.inSector = r.number === 31
+      })
+      break
+    case 'custom':
+      break
+  }
+}
+
+// Заполнить открытые сектора из первого варианта
+function fillOpenSectors() {
+  store.answers.forEach((r) => {
+    r.displayText = r.variants[0] || ''
+  })
+}
+
+// Экспорт состояния в JSON
+function exportData() {
+  const blob = new Blob([JSON.stringify(store.$state, null, 2)], {
+    type: 'application/json',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'encounter-olymp.json'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+// Импорт состояния из JSON
+function importData(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  const reader = new FileReader()
+  reader.onload = () => {
+    try {
+      const obj = JSON.parse(reader.result as string)
+      if (Array.isArray(obj.answers) && obj.config) {
+        store.$patch(obj)
+      } else {
+        alert('Неверный формат JSON')
+      }
+    } catch {
+      alert('Ошибка при разборе JSON')
+    }
+  }
+  reader.readAsText(file)
+}
+
+// Генерация HTML таблицы Олимпийки с учётом возможного <img>
+const olympTableHtml = computed(() => {
+  const style = `
+    <style>
+      .olymp {max-width:800px;width:100%;margin: 10px 0;}
+      .olymp td {
+        border:1px solid #414141;
+        padding:10px;
+        width:120px!important;
+        text-align:center;
+        vertical-align:middle;
+      }
+      .up {color:#0F0;font-weight:bold;}
+      .cols-wrapper {display: none;}
+      h3 {display: none !important;}
+      .timer, .bonus_count, .color_bonus, .color_correct {display: block !important;}
+    </style>`
+  const layout: Cell[][] = [
+    [{ id: '01_01' }, { id: '01_17', rs: 2 }, { id: '01_25', rs: 4 }, { id: '01_29', rs: 8 }, { id: '01_31', rs: 16 }],
+    [{ id: '01_02' }, {}],
+    [{ id: '01_03' }, { id: '01_18', rs: 2 }],
+    [{ id: '01_04' }],
+    [{ id: '01_05' }, { id: '01_19', rs: 2 }, { id: '01_26', rs: 4 }],
+    [{ id: '01_06' }],
+    [{ id: '01_07' }, { id: '01_20', rs: 2 }],
+    [{ id: '01_08' }],
+    [{ id: '01_09' }, { id: '01_21', rs: 2 }, { id: '01_27', rs: 4 }],
+    [{ id: '01_10' }],
+    [{ id: '01_11' }, { id: '01_22', rs: 2 }],
+    [{ id: '01_12' }],
+    [{ id: '01_13' }, { id: '01_23', rs: 2 }, { id: '01_28', rs: 4 }],
+    [{ id: '01_14' }],
+    [{ id: '01_15' }, { id: '01_24', rs: 2 }],
+    [{ id: '01_16' }],
+  ]
+
+  let html = style + '<table class="olymp">'
+  layout.forEach((row) => {
+    html += '<tr>'
+    row.forEach((cell) => {
+      if (!cell.id) return
+      const num = parseInt(cell.id.slice(-2), 10)
+      // Выбираем между closed и open
+      let rawText =
+        previewMode.value === 'closed'
+          ? store.answers[num - 1].closedText
+          : store.answers[num - 1].displayText || store.answers[num - 1].closedText
+
+      // Если это ссылка, формируем <a><img>
+      const content = formatClosedText(rawText)
+
+      // Если в режиме «open» и есть displayText, оборачиваем в <p class="up">
+      let cellHtml = content
+      if (
+        previewMode.value === 'open' &&
+        store.answers[num - 1].displayText &&
+        !/^https?:\/\//i.test(rawText.trim())
+      ) {
+        // Только для «текстовых» открытых значений оборачиваем в <p class="up">
+        cellHtml = `<p class="up">${content}</p>`
+      }
+
+      const rsAttr = cell.rs ? `rowspan="${cell.rs}"` : ''
+      html += `<td id="${cell.id}" ${rsAttr}>${cellHtml}</td>`
+    })
+    html += '</tr>'
+  })
+  html += '</table>'
+  return html
+})
+
+// --- ФУНКЦИИ ОТПРАВКИ ---
+
+// 1) отправка «Задания» (теперь всегда закрытая таблица)
+async function onSendTask() {
+  try {
+    // Сохраняем текущий режим предпросмотра
+    const prevMode = previewMode.value
+    // Принудительно переключаем на закрытый режим
+    previewMode.value = 'closed'
+    // Формируем HTML только с закрытым содержимым
+    const htmlClosed = olympTableHtml.value
+    // Восстанавливаем прежний режим (чтобы UI не сбрасывался)
+    previewMode.value = prevMode
+
+    await sendTask(
+      store.domain,
+      store.gameId,
+      store.levelId,
+      htmlClosed
+    )
+    alert('✅ Задание отправлено')
+  } catch (e: any) {
+    alert('❌ Ошибка отправки задания: ' + e.message)
+  }
+}
+
+// 2) отправка «Секторов»
+async function onSendSector() {
+  try {
+    for (const row of store.answers) {
+      if (!row.inSector) continue
+      await sendSector(
+        store.domain,
+        store.gameId,
+        store.levelId,
+        row.variants,
+        // передаём raw closedText, обработка произойдёт внутри sendSector
+        row.closedText
+      )
+    }
+    alert('✅ Все отмеченные сектора отправлены')
+  } catch (e: any) {
+    alert('❌ Ошибка отправки секторов: ' + e.message)
+  }
+}
+
+// 3) отправка «Бонусов»
+async function onSendBonus() {
+  try {
+    const bonusesToSend = store.answers.filter((r) => r.inBonus)
+    if (bonusesToSend.length === 0) {
+      alert('ℹ️ Нет отмеченных бонусов для отправки')
+      return
+    }
+    for (const bonusRow of bonusesToSend) {
+      await sendBonuses(
+        store.domain,
+        store.gameId,
+        store.levelId,
+        [bonusRow]
+      )
+    }
+    alert('✅ Все отмеченные бонусы отправлены')
+  } catch (e: any) {
+    alert('❌ Ошибка отправки бонусов: ' + e.message)
+  }
+}
+</script>
+
+<script lang="ts">
+export default {}
+</script>
+
+<style>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -30,13 +30,34 @@ export const useAuthStore = defineStore('auth', {
   persist: true,  // сохраняем в localStorage
 })
 
+function createAnswerEntry(num: number) {
+  return {
+    number: num,
+    inSector: true,
+    inBonus: true,
+    bonusTime: {
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      negative: false,
+    },
+    variants: [''],
+    closedText: '',
+    displayText: '',
+  }
+}
+
+function createAnswers(count: number) {
+  return Array.from({ length: count }, (_, i) => createAnswerEntry(i + 1))
+}
+
 export const useUploadStore = defineStore('upload', {
   state: () => ({
     // Шаг «Настройки»
-    domain: '' as string,            // например '126'
+    domain: '' as string, // например '126'
     gameId: '' as string,
     levelId: '' as string,
-    uploadType: 'olymp' as string,   // «Олимпийка (15 секторов)»
+    uploadType: 'olymp' as string, // «Олимпийка (15 секторов)»
 
     // Параметры загрузки
     config: {
@@ -52,21 +73,21 @@ export const useUploadStore = defineStore('upload', {
     // Шаблон закрытого сектора (& → номер)
     closedPattern: '' as string,
 
-    // Данные по 15 ответам
-    answers: Array.from({ length: 15 }, (_, i) => ({
-      number: i + 1,                 // порядковый номер
-      inSector: true,                // закрывать сектор?
-      inBonus: true,                 // начислять бонус?
-      bonusTime: {                   // своё время бонуса
-        hours: 0,
-        minutes: 0,
-        seconds: 0,
-        negative: false,
-      },
-      variants: [''],                // варианты ответов
-      closedText: '',                // текст для закрытого сектора
-      displayText: '',               // текст для открытого сектора
-    })),
+    // Данные по ответам (по умолчанию 15 секторов)
+    answers: createAnswers(15),
   }),
+  actions: {
+    setUploadType(type: string) {
+      this.uploadType = type
+      const desired = type === 'olymp31' ? 31 : 15
+      if (this.answers.length > desired) {
+        this.answers = this.answers.slice(0, desired)
+      } else if (this.answers.length < desired) {
+        for (let i = this.answers.length; i < desired; i++) {
+          this.answers.push(createAnswerEntry(i + 1))
+        }
+      }
+    },
+  },
   persist: true,
 })


### PR DESCRIPTION
## Summary
- add option to select 31-sector olymp
- support dynamic answer count in store
- implement new Olymp31 component with 31-sector layout
- update upload form to load Olymp31

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840060de1408329aac0f67c3d5aaf11