### PR TITLE
Fix sector number parsing in olymp components

### DIFF
--- a/frontend/src/components/types/Olymp15/index.vue
+++ b/frontend/src/components/types/Olymp15/index.vue
@@ -368,7 +368,7 @@ const olympTableHtml = computed(() => {
     html += '<tr>'
     row.forEach((cell) => {
       if (!cell.id) return
-      const num = parseInt(cell.id.slice(-2), 10)
+      const num = parseInt(cell.id.split('_')[1], 10)
       // Выбираем между closed и open
       let rawText =
         previewMode.value === 'closed'

--- a/frontend/src/components/types/Olymp31/index.vue
+++ b/frontend/src/components/types/Olymp31/index.vue
@@ -378,7 +378,7 @@ const olympTableHtml = computed(() => {
     html += '<tr>'
     row.forEach((cell) => {
       if (!cell.id) return
-      const num = parseInt(cell.id.slice(-2), 10)
+      const num = parseInt(cell.id.split('_')[1], 10)
       // Выбираем между closed и open
       let rawText =
         previewMode.value === 'closed'


### PR DESCRIPTION
## Summary
- update sector parsing in olymp components to handle ids like `01_100`

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840970840d08329a6a4981e6c93d0e3