### PR TITLE
Fix store persist config and add root scripts

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -154,7 +154,7 @@ export const useUploadStore = defineStore(
   },
   {
     persist: {
-      paths: ['domain', 'gameId', 'levelId', 'uploadType'],
+      pick: ['domain', 'gameId', 'levelId', 'uploadType'],
     },
   }
 )

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "encounter-uploader-root",
+  "private": true,
+  "scripts": {
+    "build:frontend": "npm --prefix frontend run build",
+    "test:backend": "npm --prefix backend test",
+    "start:server": "npm --prefix server start"
+  }
+}


### PR DESCRIPTION
## Summary
- fix `persist` options in upload store
- add root `package.json` with helper scripts

## Testing
- `npm --prefix frontend run build` *(fails: vue-tsc not found)*
- `npm --prefix backend test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6840a1f1ea948329be2eb5e8a608ff23