### PR TITLE
Add upload progress overlay

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,5 +2,8 @@
   <div class="container min-h-screen py-6">
     <router-view />
   </div>
+  <UploadProgress />
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import UploadProgress from './components/UploadProgress.vue'
+</script>

--- a/frontend/src/components/UploadProgress.vue
+++ b/frontend/src/components/UploadProgress.vue
@@ -1,0 +1,46 @@
+<template>
+  <transition name="fade">
+    <div
+      v-if="progress.visible"
+      class="fixed bottom-4 right-4 bg-white text-gray-800 shadow-md rounded-md p-4 w-64 z-50"
+    >
+      <button
+        v-if="progress.current >= progress.total"
+        @click="progress.close"
+        class="absolute top-1 right-1 text-gray-400 hover:text-black text-sm"
+      >
+        ✕
+      </button>
+      <div class="text-sm mb-1">
+        <span v-if="progress.type === 'sector'">Сектор</span>
+        <span v-else-if="progress.type === 'bonus'">Бонус</span>
+        <span v-else></span>
+        {{ progress.current }} / {{ progress.total }}
+      </div>
+      <div class="text-xs text-gray-500 mb-2">{{ progress.title }}</div>
+      <div class="w-full bg-gray-200 h-2 rounded">
+        <div
+          class="h-full bg-blue-500 rounded"
+          :style="{ width: progress.percent + '%' }"
+        ></div>
+      </div>
+      <div class="text-right text-xs mt-1">{{ progress.percent.toFixed(0) }}%</div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { useProgressStore } from '../store/progress'
+const progress = useProgressStore()
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/types/Olymp31/index.vue
+++ b/frontend/src/components/types/Olymp31/index.vue
@@ -202,6 +202,7 @@
 import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { useUploadStore } from '../../../store'
 import { useAuthStore } from '../../../store/auth'
+import { useProgressStore } from '../../../store/progress'
 import Answers from '../Olymp15/Answers.vue'
 
 // Функции отправки из единого uploader.ts
@@ -228,6 +229,7 @@ type Cell = { id?: string; rs?: number }
 
 const store = useUploadStore()
 const authStore = useAuthStore()
+const progress = useProgressStore()
 
 const error = ref('')
 const showPreview = ref(false)
@@ -439,17 +441,19 @@ async function onSendTask() {
 // 2) отправка «Секторов»
 async function onSendSector() {
   try {
-    for (const row of store.answers) {
-      if (!row.inSector) continue
+    const sectors = store.answers.filter((r) => r.inSector)
+    progress.start('sector', sectors.length)
+    for (const row of sectors) {
+      progress.update(`Сектор ${row.number}`)
       await sendSector(
         store.domain,
         store.gameId,
         store.levelId,
         row.variants,
-        // передаём raw closedText, обработка произойдёт внутри sendSector
         row.closedText
       )
     }
+    progress.finish()
     alert('✅ Все отмеченные сектора отправлены')
   } catch (e: any) {
     alert('❌ Ошибка отправки секторов: ' + e.message)
@@ -464,7 +468,9 @@ async function onSendBonus() {
       alert('ℹ️ Нет отмеченных бонусов для отправки')
       return
     }
+    progress.start('bonus', bonusesToSend.length)
     for (const bonusRow of bonusesToSend) {
+      progress.update(`Бонус ${bonusRow.number}`)
       await sendBonuses(
         store.domain,
         store.gameId,
@@ -472,6 +478,7 @@ async function onSendBonus() {
         [bonusRow]
       )
     }
+    progress.finish()
     alert('✅ Все отмеченные бонусы отправлены')
   } catch (e: any) {
     alert('❌ Ошибка отправки бонусов: ' + e.message)

--- a/frontend/src/store/progress.ts
+++ b/frontend/src/store/progress.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export const useProgressStore = defineStore('uploadProgress', () => {
+  const visible = ref(false)
+  const total = ref(0)
+  const current = ref(0)
+  const title = ref('')
+  const type = ref<'sector' | 'bonus' | ''>('')
+
+  function start(t: 'sector' | 'bonus', count: number) {
+    type.value = t
+    total.value = count
+    current.value = 0
+    title.value = ''
+    visible.value = true
+  }
+
+  function update(name: string) {
+    current.value += 1
+    title.value = name
+  }
+
+  function finish() {
+    title.value = 'Готово'
+  }
+
+  function close() {
+    visible.value = false
+  }
+
+  const percent = computed(() => {
+    return total.value === 0 ? 0 : Math.min((current.value / total.value) * 100, 100)
+  })
+
+  return { visible, total, current, title, type, percent, start, update, finish, close }
+})


### PR DESCRIPTION
## Summary
- show upload progress overlay for sectors and bonuses
- track progress in new pinia store
- mount progress overlay in `App.vue`

## Testing
- `npm --prefix frontend run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e2fac9f48329b83c1a8610a69fe5