### PR TITLE
Fix App template root and unused import

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="container min-h-screen py-6">
-    <router-view />
+  <div>
+    <div class="container min-h-screen py-6">
+      <router-view />
+    </div>
+    <UploadProgress />
   </div>
-  <UploadProgress />
 </template>
 <script setup lang="ts">
 import UploadProgress from './components/UploadProgress.vue'

--- a/frontend/src/components/types/Type100500/index.vue
+++ b/frontend/src/components/types/Type100500/index.vue
@@ -14,7 +14,7 @@
       <!-- Tabs -->
       <div class="flex items-center gap-2 mt-6 mb-4">
         <button
-          v-for="(t, idx) in tabs"
+          v-for="(_, idx) in tabs"
           :key="idx"
           @click="activeTab = idx"
           :class="activeTab === idx ? 'bg-blue-500 text-white' : 'bg-gray-300 text-black'"
@@ -181,7 +181,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useUploadStore } from '../../../store'
 import { useAuthStore } from '../../../store/auth'
 import { useProgressStore } from '../../../store/progress'
-import { sendSector, sendBonuses, Answer } from '../../../services/uploader'
+import { sendSector, sendBonuses, type Answer } from '../../../services/uploader'
 
 const store = useUploadStore()
 const authStore = useAuthStore()


### PR DESCRIPTION
## Summary
- wrap App template in a single root div
- mark unused loop variable and import `Answer` as a type in Type100500 component

## Testing
- `npm install` *(fails: MaxListenersExceededWarning and aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9b80d4083299d53aeb1a89b0f55