### PR TITLE
Add digits selector for code generation

### DIFF
--- a/frontend/src/components/types/Type100500/index.vue
+++ b/frontend/src/components/types/Type100500/index.vue
@@ -151,44 +151,23 @@
           >✕</button>
           <textarea v-model="codesText" class="form-input h-40 w-full" placeholder="Каждый код с новой строки"></textarea>
           <div class="flex flex-col sm:flex-row sm:items-end mt-4 gap-4">
-            <div class="flex flex-col sm:flex-row flex-1 items-end gap-2">
-              <div class="relative sm:w-auto flex-1">
-                <input
-                  id="gen-count"
-                  type="number"
-                  min="1"
-                  v-model.number="genCount"
-                  class="form-input h-10 w-full sm:w-24 placeholder-transparent peer mb-0"
-                  placeholder=" "
-                />
-                <label
-                  for="gen-count"
-                  class="absolute left-3 top-2 text-gray-500 transition-all pointer-events-none
-                         peer-placeholder-shown:top-2 peer-placeholder-shown:text-base
-                         peer-focus:-top-3 peer-focus:text-xs bg-white px-1"
-                >Количество</label>
-              </div>
-              <div class="relative sm:w-auto flex-1">
-                <input
-                  id="gen-digits"
-                  type="number"
-                  min="2"
-                  max="10"
-                  v-model.number="genDigits"
-                  class="form-input h-10 w-full sm:w-24 placeholder-transparent peer mb-0"
-                  placeholder=" "
-                />
-                <label
-                  for="gen-digits"
-                  class="absolute left-3 top-2 text-gray-500 transition-all pointer-events-none
-                         peer-placeholder-shown:top-2 peer-placeholder-shown:text-base
-                         peer-focus:-top-3 peer-focus:text-xs bg-white px-1"
-                >Знаков</label>
-              </div>
+            <div class="flex flex-1 w-full sm:w-auto items-stretch gap-0">
+              <select
+                v-model.number="genDigits"
+                class="form-select h-10 w-20 sm:w-24 rounded-r-none mb-0"
+              >
+                <option v-for="n in 9" :key="n" :value="n + 1">{{ n + 1 }}</option>
+              </select>
+              <input
+                type="number"
+                min="1"
+                v-model.number="genCount"
+                class="form-input h-10 flex-1 sm:w-24 rounded-none mb-0"
+              />
               <button
                 @click="generateCodes(genDigits)"
                 type="button"
-                class="form-button h-10 px-4 whitespace-nowrap flex-shrink-0"
+                class="form-button h-10 px-4 rounded-l-none whitespace-nowrap"
               >
                 Сгенерировать
               </button>

--- a/frontend/src/components/types/Type100500/index.vue
+++ b/frontend/src/components/types/Type100500/index.vue
@@ -160,11 +160,16 @@
                 class="form-input h-10 w-25"
                 placeholder="кол-во"
               />
-              <button @click="generateCodes(4)" type="button" class="form-button h-10 px-2 whitespace-nowrap">
-                4-х знаков
-              </button>
-              <button @click="generateCodes(5)" type="button" class="form-button h-10 px-2 whitespace-nowrap">
-                5-ти знаков
+              <input
+                type="number"
+                min="2"
+                max="10"
+                v-model.number="genDigits"
+                class="form-input h-10 w-25"
+                placeholder="знаков"
+              />
+              <button @click="generateCodes(genDigits)" type="button" class="form-button h-10 px-2 whitespace-nowrap">
+                Сгенерировать
               </button>
             </div>
             <div class="text-right">
@@ -210,6 +215,7 @@ const activeTab = ref(0)
 const showCodes = ref(false)
 const codesText = ref('')
 const genCount = ref(1)
+const genDigits = ref(4)
 const combineSectors = ref(false)
 
 function createTab(): TabData {

--- a/frontend/src/components/types/Type100500/index.vue
+++ b/frontend/src/components/types/Type100500/index.vue
@@ -143,13 +143,14 @@
     <!-- Add codes modal -->
     <transition name="fade">
       <div v-if="showCodes" class="fixed inset-0 bg-gray-600 bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50">
-        <div class="bg-white p-6 rounded-md w-[90%] max-w-xl space-y-4 relative">
+        <div class="bg-white p-6 rounded-md w-[90%] max-w-2xl space-y-4 relative">
           <button
             @click="showCodes = false"
             type="button"
             class="absolute top-2 right-2 text-gray-400 hover:text-black cursor-pointer"
           >✕</button>
           <textarea v-model="codesText" class="form-input h-40 w-full" placeholder="Каждый код с новой строки"></textarea>
+          <p class="text-sm text-right text-gray-500">{{ codesCount }} кодов</p>
           <div class="flex flex-col sm:flex-row sm:items-end mt-4 gap-4">
             <div class="flex flex-1 w-full sm:w-auto items-stretch gap-0">
               <select
@@ -172,12 +173,10 @@
                 Сгенерировать
               </button>
             </div>
-            <button
-              @click="applyCodes"
-              class="form-button h-10 px-4 self-end sm:self-auto"
-            >
-              Готово
-            </button>
+            <div class="flex gap-2 self-end sm:self-auto">
+              <button @click="applyCodes" class="form-button h-10 px-4">Готово</button>
+              <button @click="codesText = ''" class="form-button h-10 px-4">Очистить</button>
+            </div>
           </div>
         </div>
       </div>
@@ -217,6 +216,12 @@ const tabs = ref<TabData[]>([])
 const activeTab = ref(0)
 const showCodes = ref(false)
 const codesText = ref('')
+const codesCount = computed(() =>
+  codesText.value
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l).length
+)
 const genCount = ref(1)
 const genDigits = ref(4)
 const combineSectors = ref(false)

--- a/frontend/src/components/types/Type100500/index.vue
+++ b/frontend/src/components/types/Type100500/index.vue
@@ -150,31 +150,55 @@
             class="absolute top-2 right-2 text-gray-400 hover:text-black cursor-pointer"
           >✕</button>
           <textarea v-model="codesText" class="form-input h-40 w-full" placeholder="Каждый код с новой строки"></textarea>
-          <div class="flex flex-wrap justify-between items-end mt-4 gap-2">
-            <div class="flex flex-wrap items-end gap-2">
-              <label class="form-label">Сгенерить:</label>
-              <input
-                type="number"
-                min="1"
-                v-model.number="genCount"
-                class="form-input h-10 w-25"
-                placeholder="кол-во"
-              />
-              <input
-                type="number"
-                min="2"
-                max="10"
-                v-model.number="genDigits"
-                class="form-input h-10 w-25"
-                placeholder="знаков"
-              />
-              <button @click="generateCodes(genDigits)" type="button" class="form-button h-10 px-2 whitespace-nowrap">
+          <div class="flex flex-col sm:flex-row sm:items-end mt-4 gap-4">
+            <div class="flex flex-col sm:flex-row flex-1 items-end gap-2">
+              <div class="relative sm:w-auto flex-1">
+                <input
+                  id="gen-count"
+                  type="number"
+                  min="1"
+                  v-model.number="genCount"
+                  class="form-input h-10 w-full sm:w-24 placeholder-transparent peer mb-0"
+                  placeholder=" "
+                />
+                <label
+                  for="gen-count"
+                  class="absolute left-3 top-2 text-gray-500 transition-all pointer-events-none
+                         peer-placeholder-shown:top-2 peer-placeholder-shown:text-base
+                         peer-focus:-top-3 peer-focus:text-xs bg-white px-1"
+                >Количество</label>
+              </div>
+              <div class="relative sm:w-auto flex-1">
+                <input
+                  id="gen-digits"
+                  type="number"
+                  min="2"
+                  max="10"
+                  v-model.number="genDigits"
+                  class="form-input h-10 w-full sm:w-24 placeholder-transparent peer mb-0"
+                  placeholder=" "
+                />
+                <label
+                  for="gen-digits"
+                  class="absolute left-3 top-2 text-gray-500 transition-all pointer-events-none
+                         peer-placeholder-shown:top-2 peer-placeholder-shown:text-base
+                         peer-focus:-top-3 peer-focus:text-xs bg-white px-1"
+                >Знаков</label>
+              </div>
+              <button
+                @click="generateCodes(genDigits)"
+                type="button"
+                class="form-button h-10 px-4 whitespace-nowrap flex-shrink-0"
+              >
                 Сгенерировать
               </button>
             </div>
-            <div class="text-right">
-              <button @click="applyCodes" class="form-button h-10 px-4">Готово</button>
-            </div>
+            <button
+              @click="applyCodes"
+              class="form-button h-10 px-4 self-end sm:self-auto"
+            >
+              Готово
+            </button>
           </div>
         </div>
       </div>
@@ -321,6 +345,11 @@ function generateRandomCode(len: number, used: Set<string>): string {
 }
 
 function generateCodes(len: number) {
+  if (len < 2 || len > 10) {
+    alert('Количество знаков должно быть от 2 до 10')
+    return
+  }
+
   const existing = new Set<string>()
   tabs.value.forEach((t) => t.rows.forEach((r) => existing.add(r.answer.trim())))
   codesText.value
@@ -328,6 +357,15 @@ function generateCodes(len: number) {
     .map((l) => l.trim())
     .filter((l) => l)
     .forEach((c) => existing.add(c))
+
+  const max = Math.pow(10, len)
+  const available = max - existing.size
+  if (genCount.value > available) {
+    alert(
+      `Невозможно сгенерировать ${genCount.value} уникальных кодов. Доступно только ${available}.`
+    )
+    return
+  }
 
   const arr: string[] = []
   for (let i = 0; i < genCount.value; i++) {


### PR DESCRIPTION
## Summary
- unify code generation button and allow choosing length from 2-10 digits

## Testing
- `npm --prefix frontend run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eec8ec6883298e9abceb449a7df8